### PR TITLE
removed hack for getting site id and question id

### DIFF
--- a/SOUP.user.js
+++ b/SOUP.user.js
@@ -1885,6 +1885,8 @@ var soupLateSetup = function () {
 		var sid, qid;
 		sid = StackExchange.options.site.id;
 		qid = StackExchange.question.getQuestionId();
+		var re = /\bStackExchange\.realtime\.subscribeToQuestion\(\s*['"]?(\d+)['"]?\s*,\s*['"]?(\d+)['"]?\)/;
+		
 		if ( !sid || !qid || ! StackExchange.realtime ) return;
 		StackExchange.realtime.genericSubscribe( sid + '-question-' + qid, function ( json ) {
 			var data = $.parseJSON( json );

--- a/SOUP.user.js
+++ b/SOUP.user.js
@@ -1882,13 +1882,9 @@ var soupLateSetup = function () {
 	// subscribe to SE realtime question events
 	// TODO: eavesdrop on SE event traffic by hacking WebSocket or EventEmitter instead (would make this work in review too!)
 	if ( window.StackExchange && StackExchange.ready ) StackExchange.ready( function () {
-		// ewww... UGLY HACK to extract site and question IDs from page scripts
 		var sid, qid;
-		var re = /\bStackExchange\.realtime\.subscribeToQuestion\(\s*['"]?(\d+)['"]?\s*,\s*['"]?(\d+)['"]?\)/;
-		$('script').each( function () {
-			var match = re.exec( this.textContent );
-			if ( match ) { sid = match[1], qid = match[2] }
-		} );  
+		sid = StackExchange.options.site.id;
+		qid = StackExchange.question.getQuestionId();
 		if ( !sid || !qid || ! StackExchange.realtime ) return;
 		StackExchange.realtime.genericSubscribe( sid + '-question-' + qid, function ( json ) {
 			var data = $.parseJSON( json );


### PR DESCRIPTION
used built in SE functions to retrieve the site id and question id without having to loop through the scripts and extract them manually.