### PR TITLE
Fix mse250081

### DIFF
--- a/SOUP.user.js
+++ b/SOUP.user.js
@@ -151,7 +151,7 @@ fixes.mse248156 = {
 	css:	"#user-tab-bounties #bounties-table .started { display: none }"
 };
 fixes.mse250081 = {
-	title:	"Retract close vote UI",
+	title:	"Make it clearer when looking at a question if I've already voted to close it",
 	url:	"https://meta.stackexchange.com/q/250081",
 	credit:	"style suggested by AstroCB",
 	// FIXME: This doesn't work on pt.SO or ja.SO; should find out how this tooltip is translated there

--- a/SOUP.user.js
+++ b/SOUP.user.js
@@ -155,7 +155,7 @@ fixes.mse250081 = {
 	url:	"https://meta.stackexchange.com/q/250081",
 	credit:	"style suggested by AstroCB",
 	// FIXME: This doesn't work on pt.SO or ja.SO; should find out how this tooltip is translated there
-	css:	".close-question-link[title^=\"You voted to\"] { color: #444 }"
+	css:	".js-close-question-link[title^=\"You voted to\"] { color: #444 }"
 };
 fixes.mso287222 = {
 	title:	"Clicking between lines fails",


### PR DESCRIPTION
The class name of the close button changed, so the previous fix no longer works. Rename it to work with the newer class.